### PR TITLE
Add new pos option below_curosr (bcur)

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -44,7 +44,8 @@ height=18  ; In pixel.
 
 ; Position of the notification slide.
 position=top_right  ; Accepted values: top_right (tr), top_left (tl), bottom_right (br),
-                    ; bottom_left (bl), top_center (tc), bottom_center (bc), center (c).
+                    ; bottom_left (bl), top_center (tc), bottom_center (bc), center (c),
+                    ; below_cursor (bcur).
 
 ; The animation to use when the slide appear
 in_animation=38 ; see http://doc.qt.nokia.com/latest/qeasingcurve.html#Type-enum for types

--- a/twmnd/twmnd.pro
+++ b/twmnd/twmnd.pro
@@ -10,7 +10,7 @@ TARGET = twmnd
 TEMPLATE = app
 CONFIG += release
 DESTDIR = ../bin/
-LIBS += `pkg-config --libs-only-l dbus-1`
+LIBS += `pkg-config --libs-only-l dbus-1` -lXfixes
 QMAKE_CXXFLAGS += `pkg-config --cflags-only-I dbus-1`
 
 target.path+=/usr/local/bin

--- a/twmnd/widget.h
+++ b/twmnd/widget.h
@@ -30,6 +30,7 @@ private slots:
     void                    updateTopCenterAnimation(QVariant value);
     void                    updateBottomCenterAnimation(QVariant value);
     void                    updateCenterAnimation(QVariant value);
+    void                    updateBelowCursorAnimation(QVariant value);
     void                    startBounce();
     void                    unbounce();
     void                    doneBounce();


### PR DESCRIPTION
I added this because I need to make attribution easily, see http://www.justin.tv/livibetter/b/294546823 as demonstration.

There are minor issues (not to me):
- The notification does not follow the cursor after showing up at initial position, unless next bounce starts. This can be worked around in bouncing animation function (when updating y position), I think. I didn't really read the code, I just inserted parts I need.
- When scrolling as you could see I tried in that video, the position would be updated. And that causes notification gets below the cursor again, but this is not really a desired behavior. I could live with this, it shouldn't be hard to fix, but I didn't.

(edit) This hack includes the link to Xfixes, I don't know how I can get current cursor size in Qt. So it should be fine if use generally common cursor height, but I happened to know Xfixes, so I used it to get the height. You can remove it it has too many dependencies already.

(I really love it bouncing)
