### PR TITLE
Rename .markdown to .md and fix AUR link

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ sound_command=  ;  Path to command. Leave empty for no sound.
 Installation
 ------------
 
-For [Arch Linux](http://www.archlinux.org/) users, `twmn` is [on the AUR](https://aur.archlinux.org/packages.php?ID=51596).
+For [Arch Linux](http://www.archlinux.org/) users, `twmn` is [on the AUR](https://aur.archlinux.org/packages/twmn-git/).
 
 Otherwise you can install `twmnd` and `twmnc` manually:
 


### PR DESCRIPTION
I moved the package from AUR3 to AUR4. If you would like (co-?)ownership of it, please tell me.

Also, .md is usually more used than .markdown.