### PR TITLE
Add note about qt library dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ For [Arch Linux](http://www.archlinux.org/) users, `twmn` is [on the AUR](https:
 
 Otherwise you can install `twmnd` and `twmnc` manually:
 
-1. install `boost` and `qt` if they weren't before
+1. install `boost` and `qt` if they weren't before, including the `widgets` and `x11extras` qt libraries
 2. `git clone https://github.com/sboli/twmn.git` to get `twmn`
 3. `cd twmn/`
 4. `qmake` to generate a Makefile


### PR DESCRIPTION
Compiling on Ubuntu after finding this for my arch box.

I believe all the deps were:
`apt-get install qt5-qmake qtbase5-dev libqt5x11extras5-dev libqt5widgets5 python-dbus python-mpd libboost-dev libboost-system-dev libboost-program-options-dev`
