### PR TITLE
Host address selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,9 @@ duration=3000  ; In millisecond.
 ; Enable or disable shortcuts.
 enable_shortcuts=true  ; true or false.
 
+; Host address to listen on for notifications.
+host=127.0.0.1
+
 ; UDP port used for notifications.
 port=9797
 

--- a/twmnd/settings.cpp
+++ b/twmnd/settings.cpp
@@ -4,6 +4,7 @@
 Settings::Settings(QString file) : m_file(file)
 {
     m_defaultSettings["main/port"] = 9797;
+    m_defaultSettings["main/host"] = "127.0.0.1";
     m_defaultSettings["main/sound_command"] = "";
     m_defaultSettings["main/activate_command"] = "";
     m_defaultSettings["main/duration"] = "3000";

--- a/twmnd/widget.cpp
+++ b/twmnd/widget.cpp
@@ -62,7 +62,8 @@ void Widget::connectToDBus(const DBusInterface& dbus)
 void Widget::init()
 {
     int port = m_settings.get("main/port").toInt();
-    if (!m_socket.bind(QHostAddress::Any, port)) {
+    QHostAddress host = QHostAddress(m_settings.get("main/host").toString());
+    if (!m_socket.bind(host, port)) {
         qCritical() << "Unable to listen port" << port;
         return;
     }


### PR DESCRIPTION
This PR adds the ability to set the listening address on the host in the config file. It also sets 127.0.0.1 as a secure default listening address.
