### PR TITLE
Fix deprecation warnings for Qt 5.15+

### DIFF
--- a/twmnd/widget.h
+++ b/twmnd/widget.h
@@ -127,6 +127,8 @@ private:
 
     inline std::size_t      getHeight();
 
+    QRect                   getScreenRect();
+
 private:
     Settings                m_settings;
     QUdpSocket              m_socket;

--- a/twmnd/widget.h
+++ b/twmnd/widget.h
@@ -128,6 +128,7 @@ private:
     inline std::size_t      getHeight();
 
     QRect                   getScreenRect();
+    bool                    startMessageCommand(const Message& m, const char* key);
 
 private:
     Settings                m_settings;


### PR DESCRIPTION
The only loss is that XFD fonts are no longer supported (setting a raw name was a no-op pretty much since Qt 5.3).
Another feature change is that horizontal scrolling will also work for switching to next/previous.

Since there is `-Werror` in the build flags, the warnings were breaking the build.

Closes #85