### PR TITLE
Fix spec version

### DIFF
--- a/twmnd/dbusinterface.cpp
+++ b/twmnd/dbusinterface.cpp
@@ -29,7 +29,7 @@ void DBusInterface::GetServerInformation(
     name = "twmnd";
     vendor = "twmnd";
     version = "1.0";
-    specVersion = "0";
+    specVersion = "1.2";
 }
 
 void DBusInterface::CloseNotification(unsigned int id)


### PR DESCRIPTION
As far as I can tell, twmnd correctly implements version 1.2 of the notification spec (current since 2011 or so):
https://specifications.freedesktop.org/notification-spec/latest/